### PR TITLE
Update restore script to point to new migrate script

### DIFF
--- a/restore.sh
+++ b/restore.sh
@@ -16,7 +16,7 @@ cp ./uwazi-fixtures/uploaded_documents/* ./uploaded_documents/
 
 echo "Running migrations..."
 if [ $TRANSPILED = true ]; then
-  node --max-http-header-size 20000 ./prod/app/api/migrations/migrate.js
+  node --max-http-header-size 20000 ./prod/scripts/migrate.js
 else
   yarn migrate
 fi


### PR DESCRIPTION
Related to: https://github.com/huridocs/uwazi/pull/4153

Migration script has been moved to `scripts/migrate.js` 